### PR TITLE
Compiler-related fixes

### DIFF
--- a/f-list_admin.c
+++ b/f-list_admin.c
@@ -194,12 +194,12 @@ PurpleCmdRet flist_admin_op_deop_cmd(PurpleConversation *convo, const gchar *cmd
     flags = flist_get_flags(fla, NULL, fla->proper_character);
     if(!(flags & FLIST_FLAG_ADMIN)) {
         *error = g_strdup(_("You must be an administrator to add or remove global operators."));
-        return PURPLE_CMD_STATUS_FAILED;
+        return PURPLE_CMD_RET_FAILED;
     }
 
     if(!purple_utf8_strcasecmp(cmd, "op")) code = FLIST_CHANNEL_BAN;
     if(!purple_utf8_strcasecmp(cmd, "deop")) code = FLIST_CHANNEL_UNBAN;
-    if(!code) return PURPLE_CMD_STATUS_NOT_FOUND;
+    if(!code) return PURPLE_CMD_RET_FAILED;
 
     character = args[0];
 
@@ -208,7 +208,7 @@ PurpleCmdRet flist_admin_op_deop_cmd(PurpleConversation *convo, const gchar *cmd
     flist_request(pc, code, json);
     json_object_unref(json);
 
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_global_kick_ban_unban_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -222,14 +222,14 @@ PurpleCmdRet flist_global_kick_ban_unban_cmd(PurpleConversation *convo, const gc
     flags = flist_get_flags(fla, NULL, fla->proper_character);
     if(!(flags & (FLIST_FLAG_ADMIN | FLIST_FLAG_GLOBAL_OP))) {
         *error = g_strdup(_("You must be a global operator to globally kick, ban, or unban."));
-        return PURPLE_CMD_STATUS_FAILED;
+        return PURPLE_CMD_RET_FAILED;
     }
 
     if(!purple_utf8_strcasecmp(cmd, "gkick")) code = FLIST_GLOBAL_KICK;
     if(!purple_utf8_strcasecmp(cmd, "ipban")) code = FLIST_GLOBAL_IP_BAN;
     if(!purple_utf8_strcasecmp(cmd, "accountban")) code = FLIST_GLOBAL_ACCOUNT_BAN;
     if(!purple_utf8_strcasecmp(cmd, "gunban")) code = FLIST_GLOBAL_UNBAN;
-    if(!code) return PURPLE_CMD_STATUS_NOT_FOUND;
+    if(!code) return PURPLE_CMD_RET_FAILED;
 
     character = args[0];
 
@@ -238,7 +238,7 @@ PurpleCmdRet flist_global_kick_ban_unban_cmd(PurpleConversation *convo, const gc
     flist_request(pc, code, json);
     json_object_unref(json);
 
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_create_kill_channel_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -252,12 +252,12 @@ PurpleCmdRet flist_create_kill_channel_cmd(PurpleConversation *convo, const gcha
     flags = flist_get_flags(fla, NULL, fla->proper_character);
     if(!(flags & (FLIST_FLAG_ADMIN | FLIST_FLAG_GLOBAL_OP))) {
         *error = g_strdup(_("You must be a global operator to create or delete public channels."));
-        return PURPLE_CMD_STATUS_FAILED;
+        return PURPLE_CMD_RET_FAILED;
     }
 
     if(!purple_utf8_strcasecmp(cmd, "createchannel")) code = FLIST_PUBLIC_CHANNEL_CREATE;
     if(!purple_utf8_strcasecmp(cmd, "killchannel")) code = FLIST_PUBLIC_CHANNEL_DELETE;
-    if(!code) return PURPLE_CMD_STATUS_NOT_FOUND;
+    if(!code) return PURPLE_CMD_RET_FAILED;
 
     channel = args[0];
 
@@ -266,7 +266,7 @@ PurpleCmdRet flist_create_kill_channel_cmd(PurpleConversation *convo, const gcha
     flist_request(pc, code, json);
     json_object_unref(json);
 
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_broadcast_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -279,7 +279,7 @@ PurpleCmdRet flist_broadcast_cmd(PurpleConversation *convo, const gchar *cmd, gc
     flags = flist_get_flags(fla, NULL, fla->proper_character);
     if(!(flags & (FLIST_FLAG_ADMIN))) {
         *error = g_strdup(_("You must be an administrator to send a global broadcast."));
-        return PURPLE_CMD_STATUS_FAILED;
+        return PURPLE_CMD_RET_FAILED;
     }
 
     message = args[0];
@@ -289,7 +289,7 @@ PurpleCmdRet flist_broadcast_cmd(PurpleConversation *convo, const gchar *cmd, gc
     flist_request(pc, FLIST_BROADCAST, json);
     json_object_unref(json);
 
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_timeout_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -304,7 +304,7 @@ PurpleCmdRet flist_timeout_cmd(PurpleConversation *convo, const gchar *cmd, gcha
     flags = flist_get_flags(fla, NULL, fla->proper_character);
     if(!(flags & (FLIST_FLAG_ADMIN | FLIST_FLAG_GLOBAL_OP))) {
         *error = g_strdup(_("You must be a global operator to timeban."));
-        return PURPLE_CMD_STATUS_FAILED;
+        return PURPLE_CMD_RET_FAILED;
     }
 
     split = g_strsplit(args[0], ",", 3);
@@ -313,7 +313,7 @@ PurpleCmdRet flist_timeout_cmd(PurpleConversation *convo, const gchar *cmd, gcha
     if(count < 3) {
         g_strfreev(split);
         *error = g_strdup(_("You must enter a character, a time, and a reason."));
-        return PURPLE_CMD_STATUS_WRONG_ARGS;
+        return PURPLE_CMD_RET_FAILED;
     }
 
     character = split[0];
@@ -324,7 +324,7 @@ PurpleCmdRet flist_timeout_cmd(PurpleConversation *convo, const gchar *cmd, gcha
     if(time_parsed == 0 || endptr != time + strlen(time)) {
         g_strfreev(split);
         *error = g_strdup(_("You must enter a valid length of time."));
-        return PURPLE_CMD_STATUS_WRONG_ARGS;
+        return PURPLE_CMD_RET_FAILED;
     }
 
     json = json_object_new();
@@ -334,7 +334,7 @@ PurpleCmdRet flist_timeout_cmd(PurpleConversation *convo, const gchar *cmd, gcha
     flist_request(pc, FLIST_GLOBAL_TIMEOUT, json);
     json_object_unref(json);
     g_strfreev(split);
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_reward_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -347,7 +347,7 @@ PurpleCmdRet flist_reward_cmd(PurpleConversation *convo, const gchar *cmd, gchar
     flags = flist_get_flags(fla, NULL, fla->proper_character);
     if(!(flags & (FLIST_FLAG_ADMIN | FLIST_FLAG_GLOBAL_OP))) {
         *error = g_strdup(_("You must be a global operator to reward a user."));
-        return PURPLE_CMD_STATUS_FAILED;
+        return PURPLE_CMD_RET_FAILED;
     }
 
     character = args[0];
@@ -357,7 +357,7 @@ PurpleCmdRet flist_reward_cmd(PurpleConversation *convo, const gchar *cmd, gchar
     flist_request(pc, FLIST_REWARD, json);
     json_object_unref(json);
 
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 void flist_send_sfc_confirm(PurpleConnection *pc, const gchar *callid) {

--- a/f-list_autobuddy.c
+++ b/f-list_autobuddy.c
@@ -50,7 +50,7 @@ void flist_apply_filter(FListAccount *fla, GSList *candidates) {
     cur = candidates;
     while(cur) {
         const gchar *name = cur->data; cur = g_slist_next(cur);
-        purple_debug_info("flist", "adding %s\n", name);
+        purple_debug_info(FLIST_DEBUG, "adding %s\n", name);
         PurpleBuddy *b = purple_find_buddy(fla->pa, name);
         if(!b) { /* we're adding a new buddy */
             b = purple_buddy_new(fla->pa, name, NULL);

--- a/f-list_callbacks.c
+++ b/f-list_callbacks.c
@@ -46,7 +46,7 @@ static void flist_purple_find_chats_in_node(PurpleAccount *pa, PurpleBlistNode *
 /*static void flist_purple_find_buddies_in_node(PurpleAccount *pa, PurpleBlistNode *n, GSList **current) {
     while(n) {
         if(PURPLE_BLIST_NODE_IS_BUDDY(n) && PURPLE_BUDDY(n)->account == pa) {
-            purple_debug_info("flist", "found buddy: %s %x\n", purple_buddy_get_name(PURPLE_BUDDY(n)), n);
+            purple_debug_info(FLIST_DEBUG, "found buddy: %s %x\n", purple_buddy_get_name(PURPLE_BUDDY(n)), n);
             *current = g_slist_prepend(*current, n);
         }
         if(n->child) flist_purple_find_buddies_in_node(pa, n->child, current);
@@ -274,7 +274,7 @@ static gboolean flist_process_MSG(PurpleConnection *pc, JsonObject *root) {
 
     convo = purple_find_conversation_with_account(PURPLE_CONV_TYPE_CHAT, channel, pa);
     if(!convo) {
-        purple_debug_error("flist", "Received message for channel %s, but we are not in this channel.\n", channel);
+        purple_debug_error(FLIST_DEBUG, "Received message for channel %s, but we are not in this channel.\n", channel);
         return TRUE;
     }
 
@@ -289,7 +289,7 @@ static gboolean flist_process_MSG(PurpleConnection *pc, JsonObject *root) {
     else
       parsed = flist_bbcode_to_html(fla, convo, message);
 
-    purple_debug_info("flist", "Message: %s\n", parsed);
+    purple_debug_info(FLIST_DEBUG, "Message: %s\n", parsed);
     if(show && !flist_ignore_character_is_ignored(pc, character)) {
         serv_got_chat_in(pc, purple_conv_chat_get_id(PURPLE_CONV_CHAT(convo)), character, flags, parsed, time(NULL));
     }
@@ -316,7 +316,7 @@ static gboolean flist_process_LRP(PurpleConnection *pc, JsonObject *root) {
 
     convo = purple_find_conversation_with_account(PURPLE_CONV_TYPE_CHAT, channel, pa);
     if(!convo) {
-        purple_debug_error("flist", "Received advertisement for channel %s, but we are not in this channel.\n", channel);
+        purple_debug_error(FLIST_DEBUG, "Received advertisement for channel %s, but we are not in this channel.\n", channel);
         return TRUE;
     }
 
@@ -325,7 +325,7 @@ static gboolean flist_process_LRP(PurpleConnection *pc, JsonObject *root) {
 
     full_message = g_strdup_printf("[b](Roleplay Ad)[/b] %s", message);
     parsed = flist_bbcode_to_html(fla, convo, full_message);
-    purple_debug_info("flist", "Advertisement: %s\n", parsed);
+    purple_debug_info(FLIST_DEBUG, "Advertisement: %s\n", parsed);
     if(show && !flist_ignore_character_is_ignored(pc, character)) {
         serv_got_chat_in(pc, purple_conv_chat_get_id(PURPLE_CONV_CHAT(convo)), character, flags, parsed, time(NULL));
     }
@@ -369,7 +369,7 @@ static gboolean flist_process_SYS(PurpleConnection *pc, JsonObject *root) {
     if(channel) {
         convo = purple_find_conversation_with_account(PURPLE_CONV_TYPE_CHAT, channel, pa);
         if(!convo) {
-            purple_debug(PURPLE_DEBUG_ERROR, "flist", "Received system message for channel %s, but we are not in this channel.\n", channel);
+            purple_debug_error(FLIST_DEBUG, "Received system message for channel %s, but we are not in this channel.\n", channel);
             return TRUE;
         }
         parsed = flist_bbcode_to_html(fla, convo, message);

--- a/f-list_channels.c
+++ b/f-list_channels.c
@@ -584,7 +584,7 @@ PurpleCmdRet flist_channel_who_cmd(PurpleConversation *convo, const gchar *cmd, 
     FListChannel *fchannel = flist_channel_find(fla, name);
     GList *chat_buddies, *list = NULL;
 
-    g_return_val_if_fail(fchannel != NULL, PURPLE_CMD_STATUS_FAILED);
+    g_return_val_if_fail(fchannel != NULL, PURPLE_CMD_RET_FAILED);
 
     chat_buddies = purple_conv_chat_get_users(PURPLE_CONV_CHAT(convo));
     while(chat_buddies) {
@@ -614,7 +614,7 @@ PurpleCmdRet flist_channel_oplist_cmd(PurpleConversation *convo, const gchar *cm
     gchar *to_print;
     GList *cur;
 
-    g_return_val_if_fail(fchannel != NULL, PURPLE_CMD_STATUS_FAILED);
+    g_return_val_if_fail(fchannel != NULL, PURPLE_CMD_RET_FAILED);
 
     str = g_string_new(NULL);
     if(!fchannel->owner && !fchannel->operators) {
@@ -639,7 +639,7 @@ PurpleCmdRet flist_channel_oplist_cmd(PurpleConversation *convo, const gchar *cm
     purple_conv_chat_write(PURPLE_CONV_CHAT(convo), "", to_print, PURPLE_MESSAGE_SYSTEM, time(NULL));
     g_free(to_print);
 
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_channel_op_deop_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -656,12 +656,12 @@ PurpleCmdRet flist_channel_op_deop_cmd(PurpleConversation *convo, const gchar *c
     flags = flist_flags_lookup(fla, convo, fla->proper_character);
     if(!(flags & (PURPLE_CBFLAGS_OP | PURPLE_CBFLAGS_FOUNDER))) {
         *error = g_strdup(_("You must be the channel owner or a global operator to add or remove channel operators."));
-        return PURPLE_CMD_STATUS_FAILED;
+        return PURPLE_CMD_RET_FAILED;
     }
 
     if(!purple_utf8_strcasecmp(cmd, "cop")) code = FLIST_CHANNEL_ADD_OP;
     if(!purple_utf8_strcasecmp(cmd, "cdeop")) code = FLIST_CHANNEL_REMOVE_OP;
-    if(!code) return PURPLE_CMD_STATUS_NOT_FOUND;
+    if(!code) return PURPLE_CMD_RET_FAILED;
 
     json = json_object_new();
     json_object_set_string_member(json, "channel", channel);
@@ -669,7 +669,7 @@ PurpleCmdRet flist_channel_op_deop_cmd(PurpleConversation *convo, const gchar *c
     flist_request(pc, code, json);
     json_object_unref(json);
 
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_channel_code_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -687,7 +687,7 @@ PurpleCmdRet flist_channel_code_cmd(PurpleConversation *convo, const gchar *cmd,
     g_free(name_escaped);
     g_free(title_escaped);
     g_free(message);
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_channel_join_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -696,7 +696,7 @@ PurpleCmdRet flist_channel_join_cmd(PurpleConversation *convo, const gchar *cmd,
     GHashTable* components = g_hash_table_new_full(g_str_hash, g_str_equal, NULL, g_free);
     g_hash_table_insert(components, CHANNEL_COMPONENTS_NAME, g_strdup(channel));
     serv_join_chat(pc, components);
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_channel_make_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -709,7 +709,7 @@ PurpleCmdRet flist_channel_make_cmd(PurpleConversation *convo, const gchar *cmd,
     flist_request(pc, FLIST_CHANNEL_CREATE, json);
     json_object_unref(json);
 
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_channel_banlist_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -722,7 +722,7 @@ PurpleCmdRet flist_channel_banlist_cmd(PurpleConversation *convo, const gchar *c
     flags = flist_flags_lookup(fla, convo, fla->proper_character);
     if(!(flags & (PURPLE_CBFLAGS_OP | PURPLE_CBFLAGS_HALFOP | PURPLE_CBFLAGS_FOUNDER))) {
         *error = g_strdup(_("You must be a channel operator to view the channel banlist."));
-        return PURPLE_CMD_STATUS_FAILED;
+        return PURPLE_CMD_RET_FAILED;
     }
 
     json = json_object_new();
@@ -730,7 +730,7 @@ PurpleCmdRet flist_channel_banlist_cmd(PurpleConversation *convo, const gchar *c
     flist_request(pc, FLIST_CHANNEL_GET_BANLIST, json);
     json_object_unref(json);
 
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_channel_open_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -743,7 +743,7 @@ PurpleCmdRet flist_channel_open_cmd(PurpleConversation *convo, const gchar *cmd,
     flags = flist_flags_lookup(fla, convo, fla->proper_character);
     if(!(flags & (PURPLE_CBFLAGS_OP | PURPLE_CBFLAGS_FOUNDER))) {
         *error = g_strdup(_("You must be the channel owner or a global operator to open or close a private channel."));
-        return PURPLE_CMD_STATUS_FAILED;
+        return PURPLE_CMD_RET_FAILED;
     }
 
     json = json_object_new();
@@ -753,7 +753,7 @@ PurpleCmdRet flist_channel_open_cmd(PurpleConversation *convo, const gchar *cmd,
     json_object_unref(json);
 
     //TODO: don't allow this on public channels?
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_channel_close_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -766,7 +766,7 @@ PurpleCmdRet flist_channel_close_cmd(PurpleConversation *convo, const gchar *cmd
     flags = flist_flags_lookup(fla, convo, fla->proper_character);
     if(!(flags & (PURPLE_CBFLAGS_OP | PURPLE_CBFLAGS_FOUNDER))) {
         *error = g_strdup(_("You must be the channel owner or a global operator to open or close a private channel."));
-        return PURPLE_CMD_STATUS_FAILED;
+        return PURPLE_CMD_RET_FAILED;
     }
 
     json_object_set_string_member(json, "channel", channel);
@@ -776,7 +776,7 @@ PurpleCmdRet flist_channel_close_cmd(PurpleConversation *convo, const gchar *cmd
     //TODO: don't allow this on public channels
 
     json_object_unref(json);
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_channel_show_topic_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -784,12 +784,12 @@ PurpleCmdRet flist_channel_show_topic_cmd(PurpleConversation *convo, const gchar
     FListAccount *fla = pc ? pc->proto_data : NULL;
     const gchar *channel;
 
-    g_return_val_if_fail(fla, PURPLE_CMD_STATUS_FAILED);
+    g_return_val_if_fail(fla, PURPLE_CMD_RET_FAILED);
 
     channel = purple_conversation_get_name(convo);
     flist_show_channel_topic(fla, channel);
 
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_channel_show_raw_topic_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -798,11 +798,11 @@ PurpleCmdRet flist_channel_show_raw_topic_cmd(PurpleConversation *convo, const g
     const gchar *channel;
     FListChannel *fchannel;
 
-    g_return_val_if_fail(fla, PURPLE_CMD_STATUS_FAILED);
+    g_return_val_if_fail(fla, PURPLE_CMD_RET_FAILED);
 
     channel = purple_conversation_get_name(convo);
     fchannel = flist_channel_find(fla, channel);
-    g_return_val_if_fail(fchannel != NULL, PURPLE_CMD_STATUS_FAILED);
+    g_return_val_if_fail(fchannel != NULL, PURPLE_CMD_RET_FAILED);
 
     if(!fchannel->topic) {
         purple_conv_chat_write(PURPLE_CONV_CHAT(convo), "", "The description for this channel is currently unset.", PURPLE_MESSAGE_SYSTEM, time(NULL));
@@ -812,7 +812,7 @@ PurpleCmdRet flist_channel_show_raw_topic_cmd(PurpleConversation *convo, const g
         g_free(escaped_topic);
     }
 
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_channel_set_topic_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -826,7 +826,7 @@ PurpleCmdRet flist_channel_set_topic_cmd(PurpleConversation *convo, const gchar 
     flags = flist_flags_lookup(fla, convo, fla->proper_character);
     if(!(flags & (PURPLE_CBFLAGS_OP | PURPLE_CBFLAGS_FOUNDER | PURPLE_CBFLAGS_HALFOP))) {
         *error = g_strdup(_("You must be a channel or global operator to set the channel topic."));
-        return PURPLE_CMD_STATUS_FAILED;
+        return PURPLE_CMD_RET_FAILED;
     }
 
     channel = purple_conversation_get_name(convo);
@@ -839,7 +839,7 @@ PurpleCmdRet flist_channel_set_topic_cmd(PurpleConversation *convo, const gchar 
     json_object_unref(json);
 
     //TODO: don't allow this on public channels? (or do we?)
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_channel_kick_ban_unban_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -855,7 +855,7 @@ PurpleCmdRet flist_channel_kick_ban_unban_cmd(PurpleConversation *convo, const g
     flags = flist_flags_lookup(fla, convo, fla->proper_character);
     if(!(flags & (PURPLE_CBFLAGS_OP | PURPLE_CBFLAGS_FOUNDER | PURPLE_CBFLAGS_HALFOP))) {
         *error = g_strdup(_("You must be a channel or global operator to kick, ban, or unban."));
-        return PURPLE_CMD_STATUS_FAILED;
+        return PURPLE_CMD_RET_FAILED;
     }
 
     if(!purple_utf8_strcasecmp(cmd, "kick")) code = FLIST_CHANNEL_KICK;
@@ -864,7 +864,7 @@ PurpleCmdRet flist_channel_kick_ban_unban_cmd(PurpleConversation *convo, const g
         code = FLIST_CHANNEL_UNBAN;
         must_be_online = FALSE;
     }
-    if(!code) return PURPLE_CMD_STATUS_NOT_FOUND;
+    if(!code) return PURPLE_CMD_RET_FAILED;
 
     channel = purple_conversation_get_name(convo);
     character = args[0];
@@ -872,7 +872,7 @@ PurpleCmdRet flist_channel_kick_ban_unban_cmd(PurpleConversation *convo, const g
     target = flist_get_character(fla, character);
     if(must_be_online && !target) {
         *error = g_strdup(_("You may only kick or ban users that are online!"));
-        return PURPLE_CMD_STATUS_FAILED;
+        return PURPLE_CMD_RET_FAILED;
     }
 
     json = json_object_new();
@@ -881,7 +881,7 @@ PurpleCmdRet flist_channel_kick_ban_unban_cmd(PurpleConversation *convo, const g
     flist_request(pc, code, json);
     json_object_unref(json);
 
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_channel_invite_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -898,7 +898,7 @@ PurpleCmdRet flist_channel_invite_cmd(PurpleConversation *convo, const gchar *cm
     flist_request(pc, FLIST_CHANNEL_INVITE, json);
     json_object_unref(json);
 
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 static void flist_channel_destroy(void *p) {

--- a/f-list_channels.c
+++ b/f-list_channels.c
@@ -46,7 +46,7 @@ static PurpleConvChatBuddyFlags flist_flags_lookup(FListAccount *fla, PurpleConv
     PurpleConvChatBuddyFlags flags = 0;
 
     if(!fchannel) {
-        purple_debug_error("flist", "Flags requested for %s in channel %s, but no channel was found.\n", identity, channel);
+        purple_debug_error(FLIST_DEBUG, "Flags requested for %s in channel %s, but no channel was found.\n", identity, channel);
         return PURPLE_CBFLAGS_NONE;
     }
 
@@ -235,13 +235,13 @@ void flist_got_channel_joined(FListAccount *fla, const gchar *name) {
     fchannel->users = g_hash_table_new_full((GHashFunc) flist_str_hash, (GEqualFunc) flist_str_equal, g_free, NULL);
     fchannel->mode = CHANNEL_MODE_BOTH;
     g_hash_table_replace(fla->chat_table, g_strdup(name), fchannel);
-    purple_debug(PURPLE_DEBUG_INFO, "flist", "We (%s) have joined channel %s.\n", fla->proper_character, name);
+    purple_debug_info(FLIST_DEBUG, "We (%s) have joined channel %s.\n", fla->proper_character, name);
 }
 
 void flist_got_channel_left(FListAccount *fla, const gchar *name) {
     flist_remove_chat(fla, name);
     g_hash_table_remove(fla->chat_table, name);
-    purple_debug(PURPLE_DEBUG_INFO, "flist", "We (%s) have left channel %s.\n", fla->proper_character, name);
+    purple_debug_info(FLIST_DEBUG, "We (%s) have left channel %s.\n", fla->proper_character, name);
 }
 
 void flist_got_channel_mode(FListAccount *fla, const gchar *channel, const gchar *mode) {
@@ -379,7 +379,7 @@ gboolean flist_process_kickban(PurpleConnection *pc, JsonObject *root, gboolean 
 
     convo = purple_find_conversation_with_account(PURPLE_CONV_TYPE_CHAT, channel, pa);
     if(!convo) {
-        purple_debug(PURPLE_DEBUG_ERROR, "flist", "User %s was kicked or banned from channel %s, but we are not in this channel.\n", channel, character);
+        purple_debug_error(FLIST_DEBUG, "User %s was kicked or banned from channel %s, but we are not in this channel.\n", channel, character);
         return TRUE;
     }
 
@@ -512,7 +512,7 @@ gboolean flist_process_LCH(PurpleConnection *pc, JsonObject *root) {
 
     convo = purple_find_conversation_with_account(PURPLE_CONV_TYPE_CHAT, channel, pa);
     if(!convo) {
-        purple_debug(PURPLE_DEBUG_ERROR, "flist", "User %s left channel %s, but we are not in this channel.\n", character, channel);
+        purple_debug_error(FLIST_DEBUG, "User %s left channel %s, but we are not in this channel.\n", character, channel);
         return TRUE;
     }
 

--- a/f-list_commands.c
+++ b/f-list_commands.c
@@ -482,7 +482,7 @@ int flist_send_message(PurpleConnection *pc, const gchar *who, const gchar *mess
         purple_conv_im_write(im, NULL, bbcode_message, flags, time(NULL));
         ret = 0; //we've already displayed it
     } else {
-        purple_debug_warning("flist", "Sent message, but convo not found. (From: %s) (To: %s)\n",
+        purple_debug_warning(FLIST_DEBUG, "Sent message, but convo not found. (From: %s) (To: %s)\n",
             fla->character, who);
         ret = 1; //display it now
     }
@@ -522,7 +522,7 @@ static void flist_send_channel_message_real(FListAccount *fla, PurpleConversatio
     JsonObject *json = json_object_new();
     gchar *stripped_message, *escaped_message, *local_message, *bbcode_message;
     const gchar *channel = purple_conversation_get_name(convo);
-    purple_debug_info("flist", "Sending message to channel... (Character: %s) (Channel: %s) (Message: %s) (Ad: %s)\n",
+    purple_debug_info(FLIST_DEBUG, "Sending message to channel... (Character: %s) (Channel: %s) (Message: %s) (Ad: %s)\n",
         fla->character, channel, message, ad ? "yes" : "no");
 
     stripped_message = purple_markup_strip_html(message); /* strip out formatting */
@@ -554,7 +554,7 @@ int flist_send_channel_message(PurpleConnection *pc, int id, const char *message
     g_return_val_if_fail((fla = pc->proto_data), -EINVAL);
 
     if (!convo) {
-        purple_debug(PURPLE_DEBUG_ERROR, "flist", "We want to send a message in channel %d, but we are not in this channel.\n", id);
+        purple_debug_error(FLIST_DEBUG, "We want to send a message in channel %d, but we are not in this channel.\n", id);
         return -EINVAL;
     }
 

--- a/f-list_commands.c
+++ b/f-list_commands.c
@@ -570,7 +570,7 @@ PurpleCmdRet flist_roll_bottle(PurpleConversation *convo, const gchar *cmd, gcha
     json_object_set_string_member(json, "dice", "bottle");
     flist_request(pc, FLIST_ROLL_DICE, json);
     json_object_unref(json);
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_roll_dice(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -581,7 +581,7 @@ PurpleCmdRet flist_roll_dice(PurpleConversation *convo, const gchar *cmd, gchar 
     json_object_set_string_member(json, "dice", args[0]);
     flist_request(pc, FLIST_ROLL_DICE, json);
     json_object_unref(json);
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_priv_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -595,7 +595,7 @@ PurpleCmdRet flist_priv_cmd(PurpleConversation *convo, const gchar *cmd, gchar *
     if(rconvo) {
         purple_conversation_present(rconvo);
     }
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_channel_show_ads_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -604,7 +604,7 @@ PurpleCmdRet flist_channel_show_ads_cmd(PurpleConversation *convo, const gchar *
     const gchar *channel = purple_conversation_get_name(convo);
     flist_set_channel_show_ads(fla, channel, TRUE);
     flist_channel_show_message(fla, channel);
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 PurpleCmdRet flist_channel_hide_ads_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
     PurpleConnection *pc = purple_conversation_get_gc(convo);
@@ -612,7 +612,7 @@ PurpleCmdRet flist_channel_hide_ads_cmd(PurpleConversation *convo, const gchar *
     const gchar *channel = purple_conversation_get_name(convo);
     flist_set_channel_show_ads(fla, channel, FALSE);
     flist_channel_show_message(fla, channel);
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 PurpleCmdRet flist_channel_show_chat_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
     PurpleConnection *pc = purple_conversation_get_gc(convo);
@@ -620,7 +620,7 @@ PurpleCmdRet flist_channel_show_chat_cmd(PurpleConversation *convo, const gchar 
     const gchar *channel = purple_conversation_get_name(convo);
     flist_set_channel_show_chat(fla, channel, TRUE);
     flist_channel_show_message(fla, channel);
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 PurpleCmdRet flist_channel_hide_chat_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
     PurpleConnection *pc = purple_conversation_get_gc(convo);
@@ -628,7 +628,7 @@ PurpleCmdRet flist_channel_hide_chat_cmd(PurpleConversation *convo, const gchar 
     const gchar *channel = purple_conversation_get_name(convo);
     flist_set_channel_show_chat(fla, channel, FALSE);
     flist_channel_show_message(fla, channel);
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_channel_send_ad(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -640,7 +640,7 @@ PurpleCmdRet flist_channel_send_ad(PurpleConversation *convo, const gchar *cmd, 
     flist_send_channel_message_real(fla, convo, fixed_message, TRUE);
 
     g_free(fixed_message);
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_channel_warning(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -654,7 +654,7 @@ PurpleCmdRet flist_channel_warning(PurpleConversation *convo, const gchar *cmd, 
 
     g_free(fixed_message);
     g_free(extended_message);
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_get_profile_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -662,7 +662,7 @@ PurpleCmdRet flist_get_profile_cmd(PurpleConversation *convo, const gchar *cmd, 
     const gchar *character = args[0];
     flist_get_profile(pc, character);
 
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 PurpleCmdRet flist_channels_cmd(PurpleConversation *convo, const gchar *cmd, gchar **args, gchar **error, void *data) {
@@ -671,7 +671,7 @@ PurpleCmdRet flist_channels_cmd(PurpleConversation *convo, const gchar *cmd, gch
 
     purple_roomlist_show_with_account(pa);
 
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 void flist_convo_print_status(PurpleConversation *convo, FListStatus status, const gchar *status_message) {
@@ -692,7 +692,7 @@ PurpleCmdRet flist_status_cmd(PurpleConversation *convo, const gchar *cmd, gchar
     gchar *status_message;
 
     if (args[0] == NULL) 
-        return PURPLE_CMD_STATUS_WRONG_ARGS;
+        return PURPLE_CMD_RET_FAILED;
 
     status = flist_parse_status(args[0]);
 
@@ -708,10 +708,10 @@ PurpleCmdRet flist_status_cmd(PurpleConversation *convo, const gchar *cmd, gchar
         flist_set_status(fla, status, status_message);
         flist_update_server_status(fla);
         flist_convo_print_status(convo, status, status_message);
-        return PURPLE_CMD_STATUS_OK;
+        return PURPLE_CMD_RET_OK;
     } else {
         *error = g_strdup(_("Unrecognized status: first argument must be one of: online, looking, busy, dnd, away"));
-        return PURPLE_CMD_STATUS_FAILED;
+        return PURPLE_CMD_RET_FAILED;
     }
 }
 
@@ -729,7 +729,7 @@ PurpleCmdRet flist_whoami_cmd(PurpleConversation *convo, const gchar *cmd, gchar
 
     g_free(message1);
 
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 void flist_init_commands() {

--- a/f-list_connection.c
+++ b/f-list_connection.c
@@ -496,7 +496,7 @@ static void flist_receive_ticket(FListWebRequestData *req_data, gpointer data, J
     purple_debug_info(FLIST_DEBUG, "Ticket received. (Account: %s) (Character: %s) (Ticket: %s)\n", fla->username, fla->character, ticket);
 
     g_hash_table_insert(ticket_table, g_strdup(fla->username), g_strdup(ticket));
-    purple_debug_info("flist", "Login Ticket: %s\n", ticket);
+    purple_debug_info(FLIST_DEBUG, "Login Ticket: %s\n", ticket);
 
     if(first) {
         flist_connect(fla);

--- a/f-list_ignore.c
+++ b/f-list_ignore.c
@@ -113,7 +113,7 @@ gboolean flist_process_IGN(PurpleConnection *pc, JsonObject *root) {
         for (size_t i = 0; i < json_array_get_length(chars); i++)
         {
             GList *row = NULL;
-            row = g_list_append(row, json_array_get_string_element(chars, i));
+            row = g_list_append(row, (gpointer) json_array_get_string_element(chars, i));
             purple_notify_searchresults_row_add(results, row);
         }
 

--- a/f-list_ignore.c
+++ b/f-list_ignore.c
@@ -141,31 +141,31 @@ PurpleCmdRet flist_ignore_cmd(PurpleConversation *convo, const gchar *cmd, gchar
     PurpleConnection *pc = purple_conversation_get_gc(convo);
     
     if (args[0] == NULL)
-        return PURPLE_CMD_STATUS_WRONG_ARGS;
+        return PURPLE_CMD_RET_FAILED;
 
     gchar *subcmd = args[0];
     if (g_ascii_strncasecmp(subcmd, "add", 3) == 0)
     {
         if (args[1] == NULL)
-            return PURPLE_CMD_STATUS_WRONG_ARGS;
+            return PURPLE_CMD_RET_FAILED;
 
         flist_ignore_list_request_add(pc, args[1]);
     }
     else if (g_ascii_strncasecmp(subcmd, "delete", 6) == 0)
     {
         if (args[1] == NULL)
-            return PURPLE_CMD_STATUS_WRONG_ARGS;
+            return PURPLE_CMD_RET_FAILED;
 
         flist_ignore_list_request_remove(pc, args[1]);
     }
     else if (g_ascii_strncasecmp(subcmd, "list", 4) == 0)
     {
         if (args[1] != NULL)
-            return PURPLE_CMD_STATUS_WRONG_ARGS;
+            return PURPLE_CMD_RET_FAILED;
 
         flist_ignore_list_request_list(pc);
     }
 
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 

--- a/f-list_json.c
+++ b/f-list_json.c
@@ -17,7 +17,7 @@ static void g_string_append_cgi(GString *str, GHashTable *table) {
     gboolean first = TRUE;
     g_hash_table_iter_init(&iter, table);
     while(g_hash_table_iter_next(&iter, &key, &value)) {
-        purple_debug_info("flist", "cgi writing key, value: %s, %s\n", (gchar *)key, (gchar *)value);
+        purple_debug_info(FLIST_DEBUG, "cgi writing key, value: %s, %s\n", (gchar *)key, (gchar *)value);
         if(!first) g_string_append(str, "&");
         g_string_append_printf(str, "%s", purple_url_encode(key));
         g_string_append(str, "=");
@@ -70,7 +70,7 @@ static gchar *http_request(const gchar *url, gboolean http11, gboolean post, con
 
         post = g_string_free(post_str, FALSE);
 
-        purple_debug_info("flist", "posting (len: %" G_GSIZE_FORMAT "): %s\n", strlen(post), post);
+        purple_debug_info(FLIST_DEBUG, "posting (len: %" G_GSIZE_FORMAT "): %s\n", strlen(post), post);
 
         g_string_append(request_str, "Content-Type: application/x-www-form-urlencoded\r\n");
         g_string_append_printf(request_str, "Content-Length: %" G_GSIZE_FORMAT "\r\n", strlen(post));

--- a/f-list_kinks.c
+++ b/f-list_kinks.c
@@ -420,7 +420,7 @@ PurpleCmdRet flist_filter_cmd(PurpleConversation *convo, const gchar *cmd, gchar
     PurpleConnection *pc = purple_conversation_get_gc(convo);
     flist_filter_real(pc, NULL); //TODO: put the proper channel title here
 
-    return PURPLE_CMD_STATUS_OK;
+    return PURPLE_CMD_RET_OK;
 }
 
 static void flist_global_kinks_cb(FListWebRequestData *req_data,

--- a/f-list_kinks.c
+++ b/f-list_kinks.c
@@ -500,7 +500,7 @@ void flist_global_kinks_load(PurpleConnection *pc) {
     fla->flist_kinks = g_new0(FListKinks, 1);
     flk = _flist_kinks(fla);
 
-    purple_debug_info("Fetching global kink list... (Account: %s) (Character: %s)\n", fla->username, fla->character);
+    purple_debug_info(FLIST_DEBUG, "Fetching global kink list... (Account: %s) (Character: %s)\n", fla->username, fla->character);
     flk->global_kinks_request = flist_web_request(JSON_KINK_LIST, NULL, TRUE, fla->secure, flist_global_kinks_cb, fla);
 
     genders = flist_get_gender_list();

--- a/f-list_kinks.c
+++ b/f-list_kinks.c
@@ -103,7 +103,7 @@ static GSList *flist_get_filter_characters(FListAccount *fla, gboolean has_extra
         PurpleConversation *convo = purple_find_conversation_with_account(PURPLE_CONV_TYPE_CHAT, fla->filter_channel, fla->pa);
         if(convo) {
             GSList *tmp = NULL;
-            purple_debug_info("flist", "We filtered on channel %s.\n", fla->filter_channel);
+            purple_debug_info(FLIST_DEBUG, "We filtered on channel %s.\n", fla->filter_channel);
             //TODO: do we have to clean this up when we're done with it? The API is unclear.
             GList *chat_users = purple_conv_chat_get_users(PURPLE_CONV_CHAT(convo));
             while(chat_users) {
@@ -114,7 +114,7 @@ static GSList *flist_get_filter_characters(FListAccount *fla, gboolean has_extra
             }
             ret = flist_g_slist_intersect_and_free(ret, tmp);
         } else {
-            purple_debug_info("flist", "We tried to filter on channel %s, but no channel was found.\n", fla->filter_channel);
+            purple_debug_info(FLIST_DEBUG, "We tried to filter on channel %s, but no channel was found.\n", fla->filter_channel);
         }
     }
 

--- a/f-list_pidgin.c
+++ b/f-list_pidgin.c
@@ -10,20 +10,20 @@ static gboolean flist_channel_activate_real(const gchar *host, const gchar *path
     PurpleConnection *pc;
     GHashTable *components;
 
-    purple_debug_info("flist", "We are attempting to join a channel. Account: %s Channel: %s\n", host, path);
+    purple_debug_info(FLIST_DEBUG, "We are attempting to join a channel. Account: %s Channel: %s\n", host, path);
     pa = flist_deserialize_account(host);
     if(!pa) {
-        purple_debug_warning("flist", "Attempt failed. The account is not found.");
+        purple_debug_warning(FLIST_DEBUG, "Attempt failed. The account is not found.");
         return FALSE;
     }
 
     pc = purple_account_get_connection(pa);
     if(!pc) {
-        purple_debug_warning("flist", "Attempt failed. The account has no connection.");
+        purple_debug_warning(FLIST_DEBUG, "Attempt failed. The account has no connection.");
         return FALSE;
     }
     if(purple_connection_get_state(pc) != PURPLE_CONNECTED) {
-        purple_debug_warning("flist", "Attempt failed. The account is not online.");
+        purple_debug_warning(FLIST_DEBUG, "Attempt failed. The account is not online.");
         return FALSE;
     }
 
@@ -42,14 +42,14 @@ static gboolean flist_channel_activate(GtkIMHtml *imhtml, GtkIMHtmlLink *link) {
     gboolean ret = FALSE;
 
     url += strlen("flistc://");
-    purple_debug_info("flist", "FList channel URL activated: %s\n", url);
+    purple_debug_info(FLIST_DEBUG, "FList channel URL activated: %s\n", url);
 
     if(!purple_url_parse(url, &host, &port, &path, &user, &password)) {
-        purple_debug_warning("flist", "The FList channel URL did not parse.");
+        purple_debug_warning(FLIST_DEBUG, "The FList channel URL did not parse.");
         return FALSE;
     }
 
-    purple_debug_info("flist", "The FList channel URL is parsed. Host: %s Path: %s\n", host, path);
+    purple_debug_info(FLIST_DEBUG, "The FList channel URL is parsed. Host: %s Path: %s\n", host, path);
 
     if(host && path) {
         gchar *host_fixed = g_strdup(purple_url_decode(host));
@@ -71,20 +71,20 @@ gboolean flist_staff_activate_real(const gchar *host, const gchar *path) {
     PurpleAccount *pa;
     PurpleConnection *pc;
 
-    purple_debug_info("flist", "We are attempting to send a staff confirmation. Account: %s Callid: %s\n", host, path);
+    purple_debug_info(FLIST_DEBUG, "We are attempting to send a staff confirmation. Account: %s Callid: %s\n", host, path);
     pa = flist_deserialize_account(host);
     if(!pa) {
-        purple_debug_warning("flist", "Attempt failed. The account is not found.");
+        purple_debug_warning(FLIST_DEBUG, "Attempt failed. The account is not found.");
         return FALSE;
     }
 
     pc = purple_account_get_connection(pa);
     if(!pc) {
-        purple_debug_warning("flist", "Attempt failed. The account has no connection.");
+        purple_debug_warning(FLIST_DEBUG, "Attempt failed. The account has no connection.");
         return FALSE;
     }
     if(purple_connection_get_state(pc) != PURPLE_CONNECTED) {
-        purple_debug_warning("flist", "Attempt failed. The account is not online.");
+        purple_debug_warning(FLIST_DEBUG, "Attempt failed. The account is not online.");
         return FALSE;
     }
 
@@ -100,14 +100,14 @@ static gboolean flist_staff_activate(GtkIMHtml *imhtml, GtkIMHtmlLink *link) {
     gboolean ret = FALSE;
 
     url += strlen("flistsfc://");
-    purple_debug_info("flist", "FList staff URL activated: %s\n", url);
+    purple_debug_info(FLIST_DEBUG, "FList staff URL activated: %s\n", url);
 
     if(!purple_url_parse(url, &host, &port, &path, &user, &password)) {
-        purple_debug_warning("flist", "The FList staff URL did not parse.");
+        purple_debug_warning(FLIST_DEBUG, "The FList staff URL did not parse.");
         return FALSE;
     }
 
-    purple_debug_info("flist", "The FList staff URL is parsed. Host: %s Path: %s\n", host, path);
+    purple_debug_info(FLIST_DEBUG, "The FList staff URL is parsed. Host: %s Path: %s\n", host, path);
 
     if(host && path) {
         gchar *host_fixed = g_strdup(purple_url_decode(host));

--- a/f-list_profile.c
+++ b/f-list_profile.c
@@ -130,7 +130,7 @@ gboolean flist_process_PRD(PurpleConnection *pc, JsonObject *root) {
     const gchar *key, *value;
 
     if(!flp->character) {
-        purple_debug(PURPLE_DEBUG_ERROR, "flist", "Profile information received, but we are not expecting profile information.\n");
+        purple_debug_error(FLIST_DEBUG, "Profile information received, but we are not expecting profile information.\n");
         return TRUE;
     }
 
@@ -157,7 +157,7 @@ gboolean flist_process_PRD(PurpleConnection *pc, JsonObject *root) {
     value = json_object_get_string_member(root, "value");
     g_hash_table_replace(flp->table, g_strdup(key), g_strdup(value));
 
-    purple_debug_info("flist", "Profile information received for %s. Key: %s. Value: %s.\n", flp->character, key, value);
+    purple_debug_info(FLIST_DEBUG, "Profile information received for %s. Key: %s. Value: %s.\n", flp->character, key, value);
 
     return TRUE;
 }


### PR DESCRIPTION
The first commit fixes a rather simple compiler warning. About the second one : while investigating the command-related bug you told me about, I found that all plugin commands returned a value from the wrong enum. I'm not sure why GCC lets this happen, but this is definitely wrong, and clang did complain about it. This change will likely not fix anything, but it makes the code more semantically correct.