### PR TITLE
Status Synchronization

### DIFF
--- a/f-list.c
+++ b/f-list.c
@@ -567,7 +567,7 @@ void flist_login(PurpleAccount *pa) {
     g_strfreev(ac_split);
 }
 
-static GList *flist_status_types(PurpleAccount *account) {
+GList *flist_status_types(PurpleAccount *account) {
     GList *types = NULL;
     PurpleStatusType *status;
 
@@ -620,7 +620,7 @@ static PurplePluginProtocolInfo prpl_info = {
     NULL,                           /* set_info */
     flist_send_typing,        /* send_typing */
     flist_get_profile,        /* get_info */
-    NULL,               /* set_status */
+    flist_purple_set_status,               /* set_status */
     NULL,                    /* set_idle */
     NULL,                    /* change_passwd */
     flist_pidgin_add_buddy,        /* add_buddy */
@@ -686,7 +686,7 @@ static PurplePluginInfo info = {
     "F-List Protocol Plugin",         /* summary */
     "F-List Protocol Plugin",         /* description */
     "TestPanther, Nelwill, Sabhak",         /* author */
-    "http://f-list.net/",    /* homepage */
+    "https://www.f-list.net/",    /* homepage */
     plugin_load,                     /* load */
     plugin_unload,                     /* unload */
     NULL,                         /* destroy */

--- a/f-list.h
+++ b/f-list.h
@@ -253,6 +253,8 @@ PurpleGroup *flist_get_im_group(FListAccount*);
 PurpleTypingState flist_typing_state(const gchar *state);
 const gchar *flist_typing_state_string(PurpleTypingState state);
 
+GList *flist_status_types(PurpleAccount *account);
+
 void flist_g_list_free(GList *to_free);
 void flist_g_list_free_full(GList *to_free, GDestroyNotify f);
 void flist_g_slist_free_full(GSList *to_free, GDestroyNotify f);

--- a/f-list_status.h
+++ b/f-list_status.h
@@ -25,6 +25,7 @@
 
 void flist_update_server_status(FListAccount *fla);
 void flist_set_status(FListAccount *fla, FListStatus status, const gchar *status_message);
+void flist_purple_set_status(PurpleAccount *account, PurpleStatus *status);
 
 const gchar *flist_get_status_message(FListAccount *fla);
 FListStatus flist_get_status(FListAccount *fla);


### PR DESCRIPTION
Hey there, I read the code from the Fchat plugin from Adium, and used it to make the status synchronization work. And, well, it works.

The only problem is that special characters like < > " & are shown like this 
![2015-08-04_22-26-27](https://cloud.githubusercontent.com/assets/13063970/9071846/e4b6f55a-3af7-11e5-913e-332dbced6568.png)

For the record, here is the status 
![2015-08-04_22-27-33](https://cloud.githubusercontent.com/assets/13063970/9071868/01ec1cae-3af8-11e5-9bd2-62fe93076170.png)

I don't really know how to fix it, as my capacities in C are quite limited. But I figured I would still share this with you.

Fixes #5 

